### PR TITLE
fix: update login label from 'Username' to 'E-mail'

### DIFF
--- a/jobapp/templates/login.html
+++ b/jobapp/templates/login.html
@@ -48,7 +48,7 @@
         </div>
         <label for="username" class="form-label" required>Username</label>
         <div class="mb-3" style="display: flex;">
-          <input type="email" name="username" class="form-control" id="email" aria-describedby="email" placeholder="Enter Username">
+          <input type="email" name="email" class="form-control" id="email" aria-describedby="email" placeholder="Enter E-Mail">
           <i class="fa-solid fa-user" style="position: absolute; right: 75px;  padding-top: 15px; cursor: pointer;"></i>
         </div>
         <label for="password" class="form-label" required>Password</label>


### PR DESCRIPTION
Changed the login form label from **'Username'** to **'E-mail'** to reflect the actual expected input field, improving user clarity.

Fixes #21 issue.

Please let me know if any changes or improvements are required.