### PR TITLE
Improve login form alignment and spacing

### DIFF
--- a/jobapp/templates/login.html
+++ b/jobapp/templates/login.html
@@ -249,6 +249,7 @@
             background: linear-gradient(135deg, #093f75 0%, #0b447e 100%);
             color: white;
             box-shadow: 0 4px 16px rgba(9, 63, 117, 0.3);
+            margin-bottom: 0 !important;
         }
 
         .btn-primary:hover {
@@ -276,7 +277,6 @@
         /* Divider */
         .divider {
             text-align: center;
-            margin: 1.5rem 0;
             position: relative;
         }
 
@@ -551,15 +551,23 @@
                         <a href="{% url 'jobapp:jobseekerreg' %}">Register Here</a>
                     </div>
 
+                    <!-- Terms Checkbox -->
+                    <div class="checkbox-wrapper">
+                        <input type="checkbox" id="terms" name="terms" required>
+                        <label for="terms">
+                            I agree to the <a href="#" id="show-terms-link">Terms of Service</a>
+                        </label>
+                    </div>
+
                     <!-- Login Button -->
-                    <div class="text-center" style="display:flex; justify-content: center; align-items: center;">
+                    <div class="text-center" style="display:flex; justify-content: center; align-items: center; padding-top:12px;">
                         <button type="submit" class="btn btn-primary">
                             <i class="fas fa-sign-in-alt"></i> Sign In
                         </button>
                     </div>
 
                     <!-- Divider -->
-                    <div class="divider" style="padding-top:12px;">
+                    <div class="divider" style="padding-top:12px; padding-bottom: 6px">
                         <span style="display: inline-block; margin-top: 10px;">Or sign in with</span>
                     </div>
 
@@ -591,13 +599,6 @@
                     </button>
 
 
-                    </div>
-                    <!-- Terms Checkbox -->
-                    <div class="checkbox-wrapper">
-                        <input type="checkbox" id="terms" name="terms" required>
-                        <label for="terms">
-                            I agree to the <a href="#" id="show-terms-link">Terms of Service</a>
-                        </label>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
This pull request addresses issue #107 by improving the alignment and spacing of elements on the login page.

Before:
<img width="474" height="814" alt="image" src="https://github.com/user-attachments/assets/c90eb9a5-7a42-43ec-bad6-4d26627ad038" />

After:
<img width="550" height="772" alt="image" src="https://github.com/user-attachments/assets/2d8dccda-53ae-4d0b-a274-69be88b7c1c2" />

