### PR TITLE
fix(ui): disable hero image tilt on hover and adjust "Right Job" underline

### DIFF
--- a/jobapp/templates/index.html
+++ b/jobapp/templates/index.html
@@ -229,6 +229,7 @@ body::before {
   font-size: clamp(3rem, 6vw, 4.5rem);
   line-height: 1.1;
   background: linear-gradient(60deg, var(--primary-blue), var(--accent-blue));
+  background-clip: text; /* add standard property for compatibility */
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   position: relative;
@@ -295,13 +296,10 @@ body::before {
     inset 0 0 8px rgba(255, 255, 255, 0.02);
 }
 
+/* Make hero image static on hover (remove tilt/scale) */
 .hero-image img:hover {
-  transform: scale(1.05) rotate(2deg);
-  box-shadow:
-    0 40px 80px rgba(0, 0, 0, 0.25),
-    0 0 30px rgba(255, 255, 255, 0.1),
-    inset 0 0 12px rgba(255, 255, 255, 0.08);
-  cursor: pointer;
+  transform: none;
+  cursor: default;
 }
 
 /* Search Box */
@@ -479,6 +477,7 @@ body::before {
   position: relative;
   display: inline-block;
   background: linear-gradient(60deg, var(--primary-blue), #00d0ff);
+  background-clip: text; /* add standard property for compatibility */
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
@@ -1148,6 +1147,9 @@ body::before {
 </script>
 
 {% block body %}
+<!-- Auth flag for JS (avoids injecting template logic into JS) -->
+<div id="authFlag" data-auth="{% if user.is_authenticated %}true{% else %}false{% endif %}" hidden></div>
+
 <!-- Dark/Light Theme Toggle Button -->
 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
   <i class="fas fa-sun" id="themeIcon"></i>
@@ -1172,9 +1174,8 @@ body::before {
             <span style="color:#196374;">One Platform.</span>
           </strong>
         </p>
-      <h1 class="fw-bold mb-3 hero-heading" 
-        style="text-shadow: 3px 3px 6px rgba(90, 90, 90, 0.185);">
-      Get The Right <span class="highlight-job">Job</span> You<span class="highlight-deserve"> Deserve</span>
+      <h1>
+      Get The <span class="highlight-job">Right Job</span> You<span class="highlight-deserve"> Deserve</span>
       </h1>
 
         <p class="mb-4">
@@ -1696,4 +1697,45 @@ body::before {
     }
   });
 
-  // Show
+  // Show popup message for login requirement
+  document.addEventListener('DOMContentLoaded', function () {
+    const searchForm = document.querySelector('.search-container');
+    const popupMessage = document.getElementById('popupMessage');
+    const authFlag = document.getElementById('authFlag');
+    const isLoggedInFlag = authFlag && authFlag.dataset.auth === 'true';
+
+    if (searchForm) {
+      searchForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        const isLoggedIn = isLoggedInFlag;
+        if (!isLoggedIn) {
+          popupMessage.style.top = '20px';
+          popupMessage.style.opacity = '1';
+          setTimeout(() => {
+            popupMessage.style.top = '-80px';
+            popupMessage.style.opacity = '0';
+          }, 3000);
+        } else {
+          this.submit();
+        }
+      });
+    }
+
+    const uploadBtn = document.getElementById('uploadBtn');
+    if (uploadBtn) {
+      uploadBtn.addEventListener('click', function () {
+        const isLoggedIn = isLoggedInFlag;
+        if (!isLoggedIn) {
+          popupMessage.style.top = '20px';
+          popupMessage.style.opacity = '1';
+          setTimeout(() => {
+            popupMessage.style.top = '-80px';
+            popupMessage.style.opacity = '0';
+          }, 3000);
+        } else {
+          window.location.href = "{% url 'jobapp:upload_resume' %}";
+        }
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
fix(ui): disable hero image tilt on hover and adjust "Right Job" underline width

- Removed hover tilt animation from hero image container
- Ensured blue underline spans the full "Right Job" text consistently