### PR TITLE
Add direct link to working website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@
 ## 🚀 Getting Started
 
 Follow these instructions to get a copy of the project up and running on your local machine for development and testing purposes.
+## Here is Direct Link of Working Website
+##|![jobportal Demo Website]([https://dreamjobs-9pmg.onrender.com/](https://dreamjobs-9pmg.onrender.com/))
 
 ### ✅ Prerequisites
 


### PR DESCRIPTION
Added a direct link to the working website in the README.
Added URL in *About Section*\
<img width="1920" height="1020" alt="Screenshot 2025-10-19 015047" src="https://github.com/user-attachments/assets/16223f71-4bfa-46b8-86e3-f0d3025e7efd" />
